### PR TITLE
[ENH] Add probability mask support to refregion CLI and library

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ This is a general-purpose CLI to create custom reference regions from anatomical
 
 **Optional Arguments:**
 
-- `--erode`, `-e`: Number of voxels to erode the selected refereence region areas by (default: 0)
+- `--erode`, `-e`: Number of voxels to erode the selected reference region areas by (default: 0)
 - `--exclude_indices`, `-x`: Indices to exclude from the reference region (space-separated integers, default: none)
 - `--dilate`, `-d`: Number of voxels to dilate the excluded areas by (default: 0)
+- `--probability_mask`, `-p`: Path to probability mask file (optional, for WM or GM probability)
+- `--probability_threshold`, `-t`: Threshold for probability mask (values >= threshold become 1, else 0)
 
 **Processing Pipeline:**
 
@@ -42,10 +44,11 @@ The tool applies the following operations in sequence:
 
 1. Load mask file and extract specified reference indices
 2. Create initial reference region from specified indices
-3. Erosion (optional): Erode the selected reference region areas by the specified number of voxels
-4. Exclude indices (optional): Identify areas to exclude from the reference region
-5. Dilation (optional): Dilate the excluded areas by the specified number of voxels
-6. Final processing: Remove any overlap between dilated excluded areas and the reference region
+3. Apply probability mask (optional): If a probability mask and threshold are provided, threshold the probability mask and multiply with the reference region
+4. Erosion (optional): Erode the selected reference region areas by the specified number of voxels
+5. Exclude indices (optional): Identify areas to exclude from the reference region
+6. Dilation (optional): Dilate the excluded areas by the specified number of voxels
+7. Final processing: Remove any overlap between dilated excluded areas and the reference region
 
 #### Examples:
 
@@ -65,6 +68,17 @@ refregion \
     --erode 1 \
     --exclude_indices 10 11 12 \
     --dilate 3 \
+    --output custom_reference_region.nii.gz
+```
+
+With probability mask (e.g., for gray matter probability):
+```bash
+refregion \
+    --mask brain_mask.nii.gz \
+    --ref_indices 1 2 3 5 8 \
+    --probability_mask gm_probability.nii.gz \
+    --probability_threshold 0.7 \
+    --erode 1 \
     --output custom_reference_region.nii.gz
 ```
 

--- a/refregion/cli/refregion.py
+++ b/refregion/cli/refregion.py
@@ -41,6 +41,20 @@ def main():
         help="Number of voxels to dialate the excluded areas by. The overlap is removed from the reference region",
     )
     parser.add_argument(
+        "--probability_mask",
+        "-p",
+        type=Path,
+        required=False,
+        help="Path to probability mask file (optional, for WM or GM probability)",
+    )
+    parser.add_argument(
+        "--probability_threshold",
+        "-t",
+        type=float,
+        required=False,
+        help="Threshold for probability mask (values >= threshold become 1, else 0)",
+    )
+    parser.add_argument(
         "--output",
         "-o",
         type=Path,
@@ -48,6 +62,10 @@ def main():
         help="Path to the output reference region file",
     )
     args = parser.parse_args()
+
+    # Validate probability mask arguments
+    if (args.probability_mask is not None) != (args.probability_threshold is not None):
+        parser.error("--probability_mask and --probability_threshold must be used together")
 
     # load images
     wrappers.custom_ref_region(
@@ -57,4 +75,6 @@ def main():
         erode_by_voxels=args.erode,
         exclude_indices=args.exclude_indices,
         dialate_by_voxels=args.dialate,
+        probability_mask_file=args.probability_mask,
+        probability_threshold=args.probability_threshold,
     )

--- a/refregion/refregion.py
+++ b/refregion/refregion.py
@@ -8,12 +8,15 @@ def custom_ref_region(
     erode_by_voxels: int,
     exclude_indices: list,
     dialate_by_voxels: int,
+    probability_mask: np.array = None,
+    probability_threshold: float = None,
 ) -> np.array:
     """Create a custom reference region.
 
-    First, the reference region is selected by including the indices in refregion_indices. Then, the reference region
-    is eroded by erode_by_voxels. Next, the excluded indices are dialated by dialate_by_voxels, and than the overlap
-    is removed from the reference region.
+    First, the reference region is selected by including the indices in refregion_indices. If a probability mask 
+    and threshold are provided, the probability mask is thresholded and multiplied with the original mask.
+    Then, the reference region is eroded by erode_by_voxels. Next, the excluded indices are dialated by 
+    dialate_by_voxels, and then the overlap is removed from the reference region.
 
     Args:
         mask (np.array): 3D binary mask
@@ -21,12 +24,19 @@ def custom_ref_region(
         erode_by_voxels (int): Number of voxels to erode the reference region by
         exclude_indices (list): List of indices to exclude from the reference region
         dialate_by_voxels (int): Number of voxels to dialate the excluded areas by
+        probability_mask (np.array, optional): 3D probability mask (values between 0-1)
+        probability_threshold (float, optional): Threshold for probability mask (>= threshold becomes 1, else 0)
     Returns:
         np.array: Custom reference region
     """
 
     refregion = np.zeros(mask.shape)
     refregion[np.isin(mask, refregion_indices)] = 1
+
+    # Apply probability mask if provided
+    if probability_mask is not None and probability_threshold is not None:
+        binary_prob_mask = (probability_mask >= probability_threshold).astype(np.uint8)
+        refregion = refregion * binary_prob_mask
 
     refregion = morphology.erode(refregion, erode_by_voxels)
 

--- a/refregion/wrappers.py
+++ b/refregion/wrappers.py
@@ -13,11 +13,22 @@ def custom_ref_region(
     erode_by_voxels: int,
     exclude_indices: list,
     dialate_by_voxels: int,
+    probability_mask_file: Path = None,
+    probability_threshold: float = None,
 ):
     # load data
     mask = nib.load(mask_file).get_fdata()
+    
+    # load probability mask if provided
+    probability_mask = None
+    if probability_mask_file is not None:
+        probability_mask = nib.load(probability_mask_file).get_fdata()
+    
     # create custom reference region
-    mask_ref = refregion.custom_ref_region(mask, refregion_indices, erode_by_voxels, exclude_indices, dialate_by_voxels)
+    mask_ref = refregion.custom_ref_region(
+        mask, refregion_indices, erode_by_voxels, exclude_indices, dialate_by_voxels,
+        probability_mask, probability_threshold
+    )
     # cast as uint8
     mask_ref = mask_ref.astype(np.uint8)
     # save output

--- a/tests/test_refregion.py
+++ b/tests/test_refregion.py
@@ -1,0 +1,126 @@
+import pytest
+import numpy as np
+from refregion.refregion import custom_ref_region
+
+
+def test_custom_ref_region_basic():
+    """Test basic custom reference region creation."""
+    # Create test data
+    mask = np.array([[[1, 2], [3, 4]], [[1, 2], [3, 4]]])
+    
+    # Test with basic parameters
+    result = custom_ref_region(mask, [1, 2], 0, [], 0)
+    
+    # Should include regions 1 and 2, exclude nothing
+    expected = np.array([[[1, 1], [0, 0]], [[1, 1], [0, 0]]])
+    assert np.array_equal(result, expected)
+
+
+def test_custom_ref_region_with_erosion():
+    """Test custom reference region with erosion."""
+    # Create test data with boundaries for erosion to be effective
+    mask = np.zeros((7, 7, 7))
+    mask[1:6, 1:6, 1:6] = 1  # 5x5x5 inner region labeled as 1
+    
+    result = custom_ref_region(mask, [1], 1, [], 0)
+    
+    # After erosion by 1 voxel, should have smaller region due to boundary effects
+    original_sum = (mask == 1).sum()
+    assert result.sum() < original_sum
+    assert result.sum() > 0  # But should still have some voxels
+
+
+def test_custom_ref_region_with_exclusion():
+    """Test custom reference region with exclusion."""
+    # Create test data with multiple regions
+    mask = np.array([
+        [[1, 1, 1], [1, 2, 1], [1, 1, 1]],
+        [[1, 1, 1], [1, 2, 1], [1, 1, 1]],
+        [[1, 1, 1], [1, 2, 1], [1, 1, 1]]
+    ])
+    
+    # Include region 1, exclude region 2 with dilation
+    result = custom_ref_region(mask, [1], 0, [2], 1)
+    
+    # Should have region 1 minus dilated region 2
+    assert result.sum() < (mask == 1).sum()
+
+
+def test_custom_ref_region_empty_result():
+    """Test case where result is empty."""
+    mask = np.ones((3, 3, 3))
+    
+    # Include region 2 (doesn't exist), should result in empty
+    result = custom_ref_region(mask, [2], 0, [], 0)
+    
+    assert result.sum() == 0
+
+
+def test_custom_ref_region_clipping():
+    """Test that result is properly clipped to [0, 1]."""
+    mask = np.array([[[1, 2], [1, 2]], [[1, 2], [1, 2]]])
+    
+    result = custom_ref_region(mask, [1, 2], 0, [], 0)
+    
+    # All values should be 0 or 1
+    assert np.all((result == 0) | (result == 1))
+    assert result.min() >= 0
+    assert result.max() <= 1
+
+
+def test_custom_ref_region_with_probability_mask():
+    """Test custom reference region with probability mask."""
+    # Create test data
+    mask = np.array([[[1, 2], [1, 2]], [[1, 2], [1, 2]]])
+    prob_mask = np.array([[[0.3, 0.7], [0.6, 0.4]], [[0.8, 0.2], [0.9, 0.5]]])
+    
+    # Test with probability threshold of 0.5
+    result = custom_ref_region(mask, [1, 2], 0, [], 0, prob_mask, 0.5)
+    
+    # Should only include regions where probability >= 0.5
+    # pos (0,0,1): mask=2, prob=0.7 -> included
+    # pos (0,1,0): mask=1, prob=0.6 -> included  
+    # pos (1,0,0): mask=1, prob=0.8 -> included
+    # pos (1,1,1): mask=2, prob=0.5 -> included (0.5 >= 0.5)
+    expected = np.array([[[0, 1], [1, 0]], [[1, 0], [1, 1]]])
+    assert np.array_equal(result, expected)
+
+
+def test_custom_ref_region_with_probability_mask_high_threshold():
+    """Test custom reference region with high probability threshold."""
+    mask = np.array([[[1, 2], [1, 2]], [[1, 2], [1, 2]]])
+    prob_mask = np.array([[[0.3, 0.7], [0.6, 0.4]], [[0.8, 0.2], [0.9, 0.5]]])
+    
+    # Test with high probability threshold of 0.8
+    result = custom_ref_region(mask, [1, 2], 0, [], 0, prob_mask, 0.8)
+    
+    # Should only include regions where probability >= 0.8
+    # pos (1,0,0): mask=1, prob=0.8 -> included
+    # pos (1,1,0): mask=2, prob=0.9 -> included
+    expected = np.array([[[0, 0], [0, 0]], [[1, 0], [1, 0]]])
+    assert np.array_equal(result, expected)
+
+
+def test_custom_ref_region_probability_mask_no_threshold():
+    """Test that probability mask is ignored without threshold."""
+    mask = np.array([[[1, 2], [1, 2]], [[1, 2], [1, 2]]])
+    prob_mask = np.array([[[0.3, 0.7], [0.6, 0.4]], [[0.8, 0.2], [0.9, 0.5]]])
+    
+    # Test with probability mask but no threshold
+    result = custom_ref_region(mask, [1, 2], 0, [], 0, prob_mask, None)
+    
+    # Should behave like normal case (no probability masking)
+    expected = np.array([[[1, 1], [1, 1]], [[1, 1], [1, 1]]])
+    assert np.array_equal(result, expected)
+
+
+def test_custom_ref_region_no_probability_mask():
+    """Test that None probability mask is handled correctly."""
+    mask = np.array([[[1, 2], [1, 2]], [[1, 2], [1, 2]]])
+    
+    # Test with None probability mask
+    result = custom_ref_region(mask, [1, 2], 0, [], 0, None, 0.5)
+    
+    # Should behave like normal case (no probability masking)
+    expected = np.array([[[1, 1], [1, 1]], [[1, 1], [1, 1]]])
+    assert np.array_equal(result, expected)

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1,0 +1,141 @@
+import pytest
+import numpy as np
+import nibabel as nib
+import tempfile
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from refregion.wrappers import custom_ref_region
+
+
+def test_custom_ref_region_wrapper_basic():
+    """Test basic wrapper functionality without probability mask."""
+    # Create temporary files for testing
+    with tempfile.TemporaryDirectory() as temp_dir:
+        mask_file = Path(temp_dir) / "mask.nii"
+        output_file = Path(temp_dir) / "output.nii"
+        
+        # Create test mask data
+        mask_data = np.array([[[1, 2], [1, 2]], [[1, 2], [1, 2]]], dtype=np.float32)
+        affine = np.eye(4)
+        
+        # Save test mask
+        nib.save(nib.Nifti1Image(mask_data, affine), mask_file)
+        
+        # Run wrapper function
+        custom_ref_region(
+            mask_file=mask_file,
+            output_file=output_file,
+            refregion_indices=[1, 2],
+            erode_by_voxels=0,
+            exclude_indices=[],
+            dialate_by_voxels=0
+        )
+        
+        # Check output file exists and has correct data
+        assert output_file.exists()
+        result_img = nib.load(output_file)
+        result_data = result_img.get_fdata()
+        
+        # Should include all regions 1 and 2
+        expected = np.array([[[1, 1], [1, 1]], [[1, 1], [1, 1]]])
+        assert np.array_equal(result_data, expected)
+
+
+def test_custom_ref_region_wrapper_with_probability_mask():
+    """Test wrapper functionality with probability mask."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        mask_file = Path(temp_dir) / "mask.nii"
+        prob_mask_file = Path(temp_dir) / "prob_mask.nii"
+        output_file = Path(temp_dir) / "output.nii"
+        
+        # Create test data
+        mask_data = np.array([[[1, 2], [1, 2]], [[1, 2], [1, 2]]], dtype=np.float32)
+        prob_data = np.array([[[0.3, 0.7], [0.6, 0.4]], [[0.8, 0.2], [0.9, 0.5]]], dtype=np.float32)
+        affine = np.eye(4)
+        
+        # Save test files
+        nib.save(nib.Nifti1Image(mask_data, affine), mask_file)
+        nib.save(nib.Nifti1Image(prob_data, affine), prob_mask_file)
+        
+        # Run wrapper function with probability mask
+        custom_ref_region(
+            mask_file=mask_file,
+            output_file=output_file,
+            refregion_indices=[1, 2],
+            erode_by_voxels=0,
+            exclude_indices=[],
+            dialate_by_voxels=0,
+            probability_mask_file=prob_mask_file,
+            probability_threshold=0.5
+        )
+        
+        # Check output
+        assert output_file.exists()
+        result_img = nib.load(output_file)
+        result_data = result_img.get_fdata()
+        
+        # Should only include regions where probability >= 0.5
+        expected = np.array([[[0, 1], [1, 0]], [[1, 0], [1, 1]]])
+        assert np.array_equal(result_data, expected)
+
+
+def test_custom_ref_region_wrapper_probability_mask_none():
+    """Test wrapper functionality with None probability mask."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        mask_file = Path(temp_dir) / "mask.nii"
+        output_file = Path(temp_dir) / "output.nii"
+        
+        # Create test mask data
+        mask_data = np.array([[[1, 2], [1, 2]], [[1, 2], [1, 2]]], dtype=np.float32)
+        affine = np.eye(4)
+        
+        # Save test mask
+        nib.save(nib.Nifti1Image(mask_data, affine), mask_file)
+        
+        # Run wrapper function with None probability mask
+        custom_ref_region(
+            mask_file=mask_file,
+            output_file=output_file,
+            refregion_indices=[1, 2],
+            erode_by_voxels=0,
+            exclude_indices=[],
+            dialate_by_voxels=0,
+            probability_mask_file=None,
+            probability_threshold=0.5
+        )
+        
+        # Check output - should behave like normal case
+        assert output_file.exists()
+        result_img = nib.load(output_file)
+        result_data = result_img.get_fdata()
+        
+        expected = np.array([[[1, 1], [1, 1]], [[1, 1], [1, 1]]])
+        assert np.array_equal(result_data, expected)
+
+
+def test_custom_ref_region_wrapper_output_dtype():
+    """Test that wrapper saves output as uint8."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        mask_file = Path(temp_dir) / "mask.nii"
+        output_file = Path(temp_dir) / "output.nii"
+        
+        # Create test mask data
+        mask_data = np.array([[[1, 2], [1, 2]], [[1, 2], [1, 2]]], dtype=np.float32)
+        affine = np.eye(4)
+        
+        # Save test mask
+        nib.save(nib.Nifti1Image(mask_data, affine), mask_file)
+        
+        # Run wrapper function
+        custom_ref_region(
+            mask_file=mask_file,
+            output_file=output_file,
+            refregion_indices=[1, 2],
+            erode_by_voxels=0,
+            exclude_indices=[],
+            dialate_by_voxels=0
+        )
+        
+        # Check output dtype
+        result_img = nib.load(output_file)
+        assert result_img.get_data_dtype() == np.uint8


### PR DESCRIPTION
 This PR adds comprehensive probability mask functionality to the refregion package, allowing users to apply probabilistic thresholding to reference region masks.

  Changes

  - CLI Enhancement: Added --probability-mask option to refregion CLI for applying probability thresholds
  - Library Extension: Extended core refregion functionality with probability mask support
  - Wrapper Updates: Updated wrappers to handle probability mask parameters
  - Documentation: Updated README with probability mask usage examples and documentation

  Files Modified

  - refregion/cli/refregion.py: Added probability mask CLI option
  - refregion/refregion.py: Core probability mask implementation
  - refregion/wrappers.py: Wrapper function updates
  - tests/test_refregion.py: New test suite for probability functionality
  - tests/test_wrappers.py: Additional wrapper tests
  - README.md: Updated documentation and examples