### PR TITLE
[fix] fix CI Poetry installation failure

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,25 +14,23 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@v3
-    
+    - uses: actions/checkout@v4
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    
+
     - name: Install Poetry
-      run: |
-        curl -sSL https://install.python-poetry.org | python3 -
-    
+      run: pipx install "poetry<2"
+
     - name: Configure Poetry
       run: |
         poetry config virtualenvs.create true
         poetry config virtualenvs.in-project true
-    
+
     - name: Install Dependencies
       run: poetry install --with dev
-      if: steps.cache.outputs.cache-hit != 'true'
     
     - name: Code Quality
       run: |


### PR DESCRIPTION
Poetry 2.x is incompatible with this project's pyproject.toml. Pin to Poetry <2, use pipx (pre-installed on runners), and update actions/checkout and actions/setup-python to v4/v5.