### PR TITLE
[ENH] Add configuration file support (M2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ python = "^3.9"
 scikit-image = "^0.24.0"
 matplotlib = "^3.9.2"
 nibabel = "^5.3.0"
+pydantic = ">=2.0,<3.0"
+pyyaml = ">=6.0,<7.0"
 
 [tool.poetry.scripts]
 ref_cerebellum = "refregion.cli.ref_cerebellum:main"

--- a/refregion/config.py
+++ b/refregion/config.py
@@ -1,0 +1,83 @@
+import json
+from pathlib import Path
+from typing import List, Optional
+
+import yaml
+from pydantic import BaseModel, Field, model_validator
+
+SUPPORTED_CONFIG_VERSION = 1
+
+
+class ReferenceRegionConfig(BaseModel):
+    name: str
+    ref_indices: List[int]
+    erode: int = Field(default=0, ge=0)
+    exclude_indices: List[int] = Field(default_factory=list)
+    dilate: int = Field(default=0, ge=0)
+    probability_mask_file: Optional[str] = None
+    probability_threshold: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    mask_file: Optional[str] = None
+    output_file: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _ref_indices_non_empty(self):
+        if len(self.ref_indices) == 0:
+            raise ValueError("ref_indices must not be empty")
+        return self
+
+
+class ConfigFile(BaseModel):
+    version: int
+    segmentation_type: Optional[str] = None
+    reference_regions: List[ReferenceRegionConfig]
+
+    @model_validator(mode="after")
+    def _validate(self):
+        if self.version != SUPPORTED_CONFIG_VERSION:
+            raise ValueError(f"Unsupported config version {self.version}, expected {SUPPORTED_CONFIG_VERSION}")
+        if len(self.reference_regions) == 0:
+            raise ValueError("reference_regions must not be empty")
+        return self
+
+
+def load_config(path: Path) -> ConfigFile:
+    """Load and validate a config file (YAML or JSON)."""
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Config file not found: {path}")
+
+    suffix = path.suffix.lower()
+    raw_text = path.read_text()
+
+    if suffix in (".yaml", ".yml"):
+        data = yaml.safe_load(raw_text)
+    elif suffix == ".json":
+        data = json.loads(raw_text)
+    else:
+        raise ValueError(f"Unsupported config file extension: {suffix} (use .yaml, .yml, or .json)")
+
+    return ConfigFile(**data)
+
+
+def save_config(config: ConfigFile, path: Path) -> None:
+    """Serialize a ConfigFile to YAML or JSON, omitting None fields."""
+    path = Path(path)
+    data = config.model_dump(exclude_none=True)
+
+    suffix = path.suffix.lower()
+    if suffix in (".yaml", ".yml"):
+        path.write_text(yaml.dump(data, default_flow_style=False, sort_keys=False))
+    elif suffix == ".json":
+        path.write_text(json.dumps(data, indent=2))
+    else:
+        raise ValueError(f"Unsupported config file extension: {suffix} (use .yaml, .yml, or .json)")
+
+
+def config_to_dict(config: ConfigFile) -> dict:
+    """Convert a ConfigFile to a plain dict (None fields excluded)."""
+    return config.model_dump(exclude_none=True)
+
+
+def config_from_dict(data: dict) -> ConfigFile:
+    """Create a ConfigFile from a plain dict."""
+    return ConfigFile(**data)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,443 @@
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+import nibabel as nib
+import numpy as np
+import pytest
+import yaml
+
+from refregion.config import (
+    SUPPORTED_CONFIG_VERSION,
+    ConfigFile,
+    ReferenceRegionConfig,
+    config_from_dict,
+    config_to_dict,
+    load_config,
+    save_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def minimal_region_dict():
+    return {"name": "cerebellum", "ref_indices": [1, 2, 3]}
+
+
+@pytest.fixture
+def full_region_dict():
+    return {
+        "name": "cerebellum",
+        "ref_indices": [601, 602, 603],
+        "erode": 2,
+        "exclude_indices": [10, 11],
+        "dilate": 3,
+        "probability_mask_file": "/data/prob.nii.gz",
+        "probability_threshold": 0.5,
+        "mask_file": "/data/mask.nii.gz",
+        "output_file": "/data/output.nii.gz",
+    }
+
+
+@pytest.fixture
+def minimal_config_dict(minimal_region_dict):
+    return {
+        "version": SUPPORTED_CONFIG_VERSION,
+        "reference_regions": [minimal_region_dict],
+    }
+
+
+@pytest.fixture
+def full_config_dict(full_region_dict):
+    return {
+        "version": SUPPORTED_CONFIG_VERSION,
+        "segmentation_type": "freesurfer",
+        "reference_regions": [full_region_dict],
+    }
+
+
+# ---------------------------------------------------------------------------
+# ReferenceRegionConfig model validation
+# ---------------------------------------------------------------------------
+
+
+def test_reference_region_minimal(minimal_region_dict):
+    """Minimal valid region: only name + ref_indices."""
+    region = ReferenceRegionConfig(**minimal_region_dict)
+    assert region.name == "cerebellum"
+    assert region.ref_indices == [1, 2, 3]
+    assert region.erode == 0
+    assert region.exclude_indices == []
+    assert region.dilate == 0
+    assert region.probability_mask_file is None
+    assert region.probability_threshold is None
+    assert region.mask_file is None
+    assert region.output_file is None
+
+
+def test_reference_region_full(full_region_dict):
+    """All fields populated."""
+    region = ReferenceRegionConfig(**full_region_dict)
+    assert region.name == "cerebellum"
+    assert region.ref_indices == [601, 602, 603]
+    assert region.erode == 2
+    assert region.exclude_indices == [10, 11]
+    assert region.dilate == 3
+    assert region.probability_mask_file == "/data/prob.nii.gz"
+    assert region.probability_threshold == 0.5
+    assert region.mask_file == "/data/mask.nii.gz"
+    assert region.output_file == "/data/output.nii.gz"
+
+
+def test_reference_region_empty_ref_indices():
+    """ref_indices must be non-empty."""
+    with pytest.raises(Exception):
+        ReferenceRegionConfig(name="bad", ref_indices=[])
+
+
+def test_reference_region_negative_erode():
+    """erode must be >= 0."""
+    with pytest.raises(Exception):
+        ReferenceRegionConfig(name="bad", ref_indices=[1], erode=-1)
+
+
+def test_reference_region_negative_dilate():
+    """dilate must be >= 0."""
+    with pytest.raises(Exception):
+        ReferenceRegionConfig(name="bad", ref_indices=[1], dilate=-1)
+
+
+def test_reference_region_threshold_below_zero():
+    """probability_threshold must be >= 0.0."""
+    with pytest.raises(Exception):
+        ReferenceRegionConfig(name="bad", ref_indices=[1], probability_threshold=-0.1)
+
+
+def test_reference_region_threshold_above_one():
+    """probability_threshold must be <= 1.0."""
+    with pytest.raises(Exception):
+        ReferenceRegionConfig(name="bad", ref_indices=[1], probability_threshold=1.5)
+
+
+# ---------------------------------------------------------------------------
+# ConfigFile model validation
+# ---------------------------------------------------------------------------
+
+
+def test_config_file_single_region(minimal_config_dict):
+    """Valid config with one region."""
+    cfg = ConfigFile(**minimal_config_dict)
+    assert cfg.version == SUPPORTED_CONFIG_VERSION
+    assert len(cfg.reference_regions) == 1
+    assert cfg.segmentation_type is None
+
+
+def test_config_file_multi_region(minimal_region_dict):
+    """Config with multiple reference regions."""
+    second = {**minimal_region_dict, "name": "pons"}
+    data = {
+        "version": SUPPORTED_CONFIG_VERSION,
+        "reference_regions": [minimal_region_dict, second],
+    }
+    cfg = ConfigFile(**data)
+    assert len(cfg.reference_regions) == 2
+    assert cfg.reference_regions[1].name == "pons"
+
+
+def test_config_file_with_segmentation_type(full_config_dict):
+    """segmentation_type is preserved."""
+    cfg = ConfigFile(**full_config_dict)
+    assert cfg.segmentation_type == "freesurfer"
+
+
+def test_config_file_unsupported_version(minimal_region_dict):
+    """version != SUPPORTED_CONFIG_VERSION should fail."""
+    data = {"version": 999, "reference_regions": [minimal_region_dict]}
+    with pytest.raises(Exception):
+        ConfigFile(**data)
+
+
+def test_config_file_empty_regions():
+    """reference_regions must be non-empty."""
+    data = {"version": SUPPORTED_CONFIG_VERSION, "reference_regions": []}
+    with pytest.raises(Exception):
+        ConfigFile(**data)
+
+
+# ---------------------------------------------------------------------------
+# YAML round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_yaml_round_trip(full_config_dict):
+    """save_config → load_config with .yaml extension."""
+    cfg = ConfigFile(**full_config_dict)
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "config.yaml"
+        save_config(cfg, path)
+        loaded = load_config(path)
+    assert loaded.version == cfg.version
+    assert loaded.reference_regions[0].name == cfg.reference_regions[0].name
+    assert loaded.reference_regions[0].ref_indices == cfg.reference_regions[0].ref_indices
+
+
+def test_yml_extension_round_trip(minimal_config_dict):
+    """load_config recognises .yml extension."""
+    cfg = ConfigFile(**minimal_config_dict)
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "config.yml"
+        save_config(cfg, path)
+        loaded = load_config(path)
+    assert loaded.version == cfg.version
+    assert len(loaded.reference_regions) == 1
+
+
+def test_yaml_excludes_none(minimal_config_dict):
+    """save_config omits None fields from YAML output."""
+    cfg = ConfigFile(**minimal_config_dict)
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "config.yaml"
+        save_config(cfg, path)
+        raw = yaml.safe_load(path.read_text())
+    region = raw["reference_regions"][0]
+    assert "probability_mask_file" not in region
+    assert "mask_file" not in region
+    assert "segmentation_type" not in raw
+
+
+# ---------------------------------------------------------------------------
+# JSON round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_json_round_trip(full_config_dict):
+    """save_config → load_config with .json extension."""
+    cfg = ConfigFile(**full_config_dict)
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "config.json"
+        save_config(cfg, path)
+        loaded = load_config(path)
+    assert loaded.version == cfg.version
+    assert loaded.reference_regions[0].name == cfg.reference_regions[0].name
+
+
+def test_json_excludes_none(minimal_config_dict):
+    """save_config omits None fields from JSON output."""
+    cfg = ConfigFile(**minimal_config_dict)
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "config.json"
+        save_config(cfg, path)
+        raw = json.loads(path.read_text())
+    region = raw["reference_regions"][0]
+    assert "probability_mask_file" not in region
+
+
+# ---------------------------------------------------------------------------
+# Error cases: load_config
+# ---------------------------------------------------------------------------
+
+
+def test_load_config_file_not_found():
+    """load_config raises FileNotFoundError for missing file."""
+    with pytest.raises(FileNotFoundError):
+        load_config(Path("/nonexistent/config.yaml"))
+
+
+def test_load_config_unsupported_extension():
+    """load_config raises ValueError for unsupported file extension."""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "config.toml"
+        path.write_text("key = 'value'")
+        with pytest.raises(ValueError):
+            load_config(path)
+
+
+def test_load_config_malformed_yaml():
+    """load_config raises on malformed YAML."""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "config.yaml"
+        path.write_text(": : : invalid yaml [[")
+        with pytest.raises(Exception):
+            load_config(path)
+
+
+def test_load_config_valid_yaml_invalid_schema():
+    """Valid YAML that doesn't match the schema should raise."""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "config.yaml"
+        path.write_text(yaml.dump({"version": 1, "reference_regions": [{"name": "x"}]}))
+        with pytest.raises(Exception):
+            load_config(path)
+
+
+# ---------------------------------------------------------------------------
+# Dict conversion
+# ---------------------------------------------------------------------------
+
+
+def test_config_to_dict(full_config_dict):
+    """config_to_dict returns a plain dict matching the input."""
+    cfg = ConfigFile(**full_config_dict)
+    d = config_to_dict(cfg)
+    assert isinstance(d, dict)
+    assert d["version"] == SUPPORTED_CONFIG_VERSION
+    assert d["reference_regions"][0]["name"] == "cerebellum"
+    # None fields should be excluded
+    assert (
+        "probability_mask_file" not in d["reference_regions"][0]
+        or d["reference_regions"][0]["probability_mask_file"] == "/data/prob.nii.gz"
+    )
+
+
+def test_config_from_dict(full_config_dict):
+    """config_from_dict round-trips through config_to_dict."""
+    cfg = ConfigFile(**full_config_dict)
+    d = config_to_dict(cfg)
+    cfg2 = config_from_dict(d)
+    assert cfg2.version == cfg.version
+    assert cfg2.reference_regions[0].name == cfg.reference_regions[0].name
+    assert cfg2.reference_regions[0].ref_indices == cfg.reference_regions[0].ref_indices
+
+
+def test_config_from_dict_invalid():
+    """config_from_dict raises on invalid dict."""
+    with pytest.raises(Exception):
+        config_from_dict({"version": 1, "reference_regions": []})
+
+
+# ---------------------------------------------------------------------------
+# CLI --config integration tests
+# ---------------------------------------------------------------------------
+
+
+def _make_mask_nifti(path, data=None):
+    """Helper: write a small NIfTI mask file."""
+    if data is None:
+        data = np.array([[[1, 2], [1, 2]], [[1, 2], [1, 2]]], dtype=np.float32)
+    nib.save(nib.Nifti1Image(data, np.eye(4)), path)
+
+
+def test_cli_config_single_region():
+    """CLI --config with a single region creates output and prints morphometrics."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        mask_path = tmp / "mask.nii"
+        output_path = tmp / "output.nii"
+        config_path = tmp / "config.yaml"
+
+        _make_mask_nifti(mask_path)
+
+        config_data = {
+            "version": SUPPORTED_CONFIG_VERSION,
+            "reference_regions": [
+                {
+                    "name": "test_region",
+                    "ref_indices": [1, 2],
+                    "erode": 0,
+                    "exclude_indices": [],
+                    "dilate": 0,
+                    "mask_file": str(mask_path),
+                    "output_file": str(output_path),
+                }
+            ],
+        }
+        config_path.write_text(yaml.dump(config_data))
+
+        result = subprocess.run(
+            ["poetry", "run", "refregion", "--config", str(config_path)],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        assert output_path.exists()
+        assert "test_region" in result.stdout
+        assert "Voxel count" in result.stdout
+
+
+def test_cli_config_multi_region():
+    """CLI --config with multiple regions creates all output files."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        mask_path = tmp / "mask.nii"
+        output1 = tmp / "out1.nii"
+        output2 = tmp / "out2.nii"
+        config_path = tmp / "config.yaml"
+
+        _make_mask_nifti(mask_path)
+
+        config_data = {
+            "version": SUPPORTED_CONFIG_VERSION,
+            "reference_regions": [
+                {
+                    "name": "region_a",
+                    "ref_indices": [1],
+                    "mask_file": str(mask_path),
+                    "output_file": str(output1),
+                },
+                {
+                    "name": "region_b",
+                    "ref_indices": [2],
+                    "mask_file": str(mask_path),
+                    "output_file": str(output2),
+                },
+            ],
+        }
+        config_path.write_text(yaml.dump(config_data))
+
+        result = subprocess.run(
+            ["poetry", "run", "refregion", "--config", str(config_path)],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        assert output1.exists()
+        assert output2.exists()
+
+
+def test_cli_config_mutually_exclusive_with_mask():
+    """--config and --mask together should produce an error."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        config_path = tmp / "config.yaml"
+        config_path.write_text(yaml.dump({"version": 1, "reference_regions": [{"name": "x", "ref_indices": [1]}]}))
+
+        result = subprocess.run(
+            ["poetry", "run", "refregion", "--config", str(config_path), "--mask", "/fake/mask.nii"],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode != 0
+
+
+def test_cli_config_region_missing_mask_file():
+    """Region without mask_file in config should produce an error."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        config_path = tmp / "config.yaml"
+        config_data = {
+            "version": SUPPORTED_CONFIG_VERSION,
+            "reference_regions": [
+                {
+                    "name": "no_mask",
+                    "ref_indices": [1],
+                    "output_file": "/tmp/out.nii",
+                }
+            ],
+        }
+        config_path.write_text(yaml.dump(config_data))
+
+        result = subprocess.run(
+            ["poetry", "run", "refregion", "--config", str(config_path)],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode != 0

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -317,7 +317,25 @@
             </div>
 
             <div class="section">
-                <h2>5. Visualization</h2>
+                <h2>5. Configuration</h2>
+                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-bottom: 15px;">
+                    <div class="control-group">
+                        <label for="region-name-input">Region Name:</label>
+                        <input type="text" id="region-name-input" value="reference_region" placeholder="e.g., cerebellum">
+                    </div>
+                </div>
+                <div class="button-group">
+                    <button id="export-config-btn">Export Config (YAML)</button>
+                    <div class="file-input-item" style="display: inline-block;">
+                        <label for="import-config-file" style="display: inline; cursor: pointer; background: #4CAF50; color: white; padding: 12px 24px; border-radius: 5px; font-size: 14px; font-weight: 600;">Import Config</label>
+                        <input type="file" id="import-config-file" accept=".yaml,.yml,.json" style="display: none;">
+                    </div>
+                </div>
+                <div id="config-status"></div>
+            </div>
+
+            <div class="section">
+                <h2>6. Visualization</h2>
                 <div class="visualization">
                     <div class="plane-view">
                         <h3>Coronal (Z)</h3>
@@ -347,7 +365,7 @@
             </div>
 
             <div class="section">
-                <h2>6. Save Processed Mask</h2>
+                <h2>7. Save Processed Mask</h2>
                 <div class="control-group" style="max-width: 500px; margin-bottom: 15px;">
                     <label for="save-filename">Filename:</label>
                     <input type="text" id="save-filename" value="processed_mask.nii.gz" placeholder="Enter filename (e.g., processed_mask.nii.gz)">
@@ -358,6 +376,6 @@
         </div>
     </div>
 
-    <script type="py" src="./app.py" config='{"packages": ["numpy", "nibabel", "scikit-image"]}'></script>
+    <script type="py" src="./app.py" config='{"packages": ["numpy", "nibabel", "scikit-image", "pyyaml"]}'></script>
 </body>
 </html>


### PR DESCRIPTION
 ## Summary

  - Add YAML/JSON configuration file support so users can define multiple reference regions in a single file and run them in batch
  via `--config`
  - New `refregion/config.py` module with Pydantic models (`ReferenceRegionConfig`, `ConfigFile`) for schema validation, versioned
  configs, and YAML/JSON I/O
  - Extend `refregion` CLI with `--config` / `-c` flag (mutually exclusive with `--mask`/`--ref_indices`/`--output`)
  - Add config export (YAML download) and import (populate UI) to the WebApp

  ## Changes

  - **`refregion/config.py`** — Pydantic models, `load_config`, `save_config`, `config_to_dict`, `config_from_dict`
  - **`refregion/cli/refregion.py`** — `--config` flag, `_run_from_config()`, runtime mutual exclusivity validation
  - **`webapp/index.html`** + **`webapp/app.py`** — Configuration section with export/import, pyyaml added to PyScript packages
  - **`pyproject.toml`** — Added `pydantic >=2.0,<3.0` and `pyyaml >=6.0,<7.0`
  - **`tests/test_config.py`** — 28 tests (model validation, YAML/JSON round-trip, error cases, CLI integration)