### PR TITLE
[fix] reorganize WebApp config UI into existing sections

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -455,9 +455,9 @@ def export_config(event):
         link.download = f"{region_name}.yaml"
         link.click()
 
-        update_status("config-status", f"Config exported as {region_name}.yaml", "success")
+        update_status("save-status", f"Config exported as {region_name}.yaml", "success")
     except Exception as e:
-        update_status("config-status", f"Error exporting config: {str(e)}", "error")
+        update_status("save-status", f"Error exporting config: {str(e)}", "error")
         console.error(str(e))
 
 
@@ -482,12 +482,12 @@ async def import_config(event):
             data = yaml.safe_load(text)
 
         if not isinstance(data, dict) or "reference_regions" not in data:
-            update_status("config-status", "Invalid config file: missing reference_regions", "error")
+            update_status("load-status", "Invalid config file: missing reference_regions", "error")
             return
 
         regions = data["reference_regions"]
         if not regions:
-            update_status("config-status", "Config file has no reference regions", "error")
+            update_status("load-status", "Config file has no reference regions", "error")
             return
 
         # Use the first region to populate UI
@@ -520,13 +520,13 @@ async def import_config(event):
         msg = f"Config imported from {filename}"
         if n_regions > 1:
             msg += f" (loaded first of {n_regions} regions)"
-        update_status("config-status", msg, "success")
+        update_status("load-status", msg, "success")
 
         # Reset file input so the same file can be re-imported
         event.target.value = ""
 
     except Exception as e:
-        update_status("config-status", f"Error importing config: {str(e)}", "error")
+        update_status("load-status", f"Error importing config: {str(e)}", "error")
         console.error(str(e))
 
 

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -270,12 +270,20 @@
                         <label for="mask-file">Segmentation Mask (NIfTI/MGZ):</label>
                         <input type="file" id="mask-file" accept=".nii,.nii.gz,.mgz">
                     </div>
+                    <div class="file-input-item">
+                        <label for="import-config-file">Configuration (YAML/JSON):</label>
+                        <input type="file" id="import-config-file" accept=".yaml,.yml,.json">
+                    </div>
                 </div>
                 <div id="load-status"></div>
             </div>
 
             <div class="section">
                 <h2>2. Select Indices</h2>
+                <div class="control-group" style="max-width: 400px; margin-bottom: 15px;">
+                    <label for="region-name-input">Region Name:</label>
+                    <input type="text" id="region-name-input" value="reference_region" placeholder="e.g., cerebellum" style="padding: 8px 12px; border: 1px solid #ddd; border-radius: 5px; font-size: 14px;">
+                </div>
                 <p style="color: #666; margin-bottom: 15px; font-size: 14px;">Available mask indices: <span id="available-indices" style="font-weight: 600; color: #4CAF50;">Load a mask file to see available indices</span></p>
                 <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
                     <div class="control-group">
@@ -317,25 +325,7 @@
             </div>
 
             <div class="section">
-                <h2>5. Configuration</h2>
-                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-bottom: 15px;">
-                    <div class="control-group">
-                        <label for="region-name-input">Region Name:</label>
-                        <input type="text" id="region-name-input" value="reference_region" placeholder="e.g., cerebellum">
-                    </div>
-                </div>
-                <div class="button-group">
-                    <button id="export-config-btn">Export Config (YAML)</button>
-                    <div class="file-input-item" style="display: inline-block;">
-                        <label for="import-config-file" style="display: inline; cursor: pointer; background: #4CAF50; color: white; padding: 12px 24px; border-radius: 5px; font-size: 14px; font-weight: 600;">Import Config</label>
-                        <input type="file" id="import-config-file" accept=".yaml,.yml,.json" style="display: none;">
-                    </div>
-                </div>
-                <div id="config-status"></div>
-            </div>
-
-            <div class="section">
-                <h2>6. Visualization</h2>
+                <h2>5. Visualization</h2>
                 <div class="visualization">
                     <div class="plane-view">
                         <h3>Coronal (Z)</h3>
@@ -365,12 +355,15 @@
             </div>
 
             <div class="section">
-                <h2>7. Save Processed Mask</h2>
+                <h2>6. Save</h2>
                 <div class="control-group" style="max-width: 500px; margin-bottom: 15px;">
                     <label for="save-filename">Filename:</label>
                     <input type="text" id="save-filename" value="processed_mask.nii.gz" placeholder="Enter filename (e.g., processed_mask.nii.gz)">
                 </div>
-                <button id="save-btn" disabled>Download Processed Mask</button>
+                <div class="button-group">
+                    <button id="save-btn" disabled>Download Processed Mask</button>
+                    <button id="export-config-btn">Export Config (YAML)</button>
+                </div>
                 <div id="save-status"></div>
             </div>
         </div>


### PR DESCRIPTION
Move config file import to Section 1 (Load Images), region name to Section 2 (Select Indices), and export button to Section 6 (Save). Remove standalone Configuration section.